### PR TITLE
fix(edit-page): add 'Return' button to navigate back to timer view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name":"Ptime Extension",
     "description":"Simple Timer Extension",
-    "version":"0.2.5",
+    "version":"0.2.6",
     "manifest_version":3,
     "action":{
         "default_popup": "src/index.html"

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
     <div id="edit-wrapper" class="container hidden">
         <h1>Ptime Extension</h1>
         <h2>Edit Timer</h2>
+        <button id="returnButton">&larr;</button>
         <div class="input-row">
             <div class="input-group">
                 <input type="number" name="hours" id="hours" min="0" max="23" value="0">

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ const resetTimerButton = document.getElementById("reset-timer");
 // Edit Wrapper Related DOM Elements
 const editWrapper = document.getElementById("edit-wrapper");
 const saveButton = document.getElementById("save");
+const returnButton = document.getElementById("returnButton");
 
 
 // Timer Related Event Listeners
@@ -62,9 +63,13 @@ saveButton.addEventListener("click", () => {
     editWrapper.classList.add("hidden");
     timerWrapper.classList.remove("hidden");
     refreshTimer();
-})
+});
 
-
+// Return Button Event Listener
+returnButton.addEventListener("click", () => {
+    editWrapper.classList.add("hidden"); // Hide edit
+    timerWrapper.classList.remove("hidden"); // Show timer
+});
 
 function formatTime(unit) {
     return String(unit).padStart(2, "0")

--- a/src/style.css
+++ b/src/style.css
@@ -95,3 +95,10 @@ button:active {
     margin: 0 auto;
     display: block;
 }
+
+#returnButton {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+}
+


### PR DESCRIPTION
- add a 'Return' button with an arrow symbol on the Edit page.
- enable toggling between Edit and Timer views.
- ensure the timer continues running while editing.
- position the button on the top-left corner for easy access.
- bump the version to v0.2.6 .

resolve #6