### PR TITLE
FEATURE: Add Keyboard Shortcut to open the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 5. The extension will now be installed and visible in the Chrome toolbar.
 
 ## Usage
-1. Click the extension icon to open the timer interface.
+1. Click the extension icon or Use the shortcut (Ctrl + Shift + Y) to open the timer interface.
 2. Press Start to begin the timer, and Pause to stop it.
 3. Click Reset to reset the timer to the last saved value.
 4. To modify the timer's settings, click the Edit button, input new values for hours, minutes, and seconds, and click Save.

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,14 @@
             "128": "src/resource/logo128.png"
         }
     },
+    "commands": {
+        "_execute_action": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+Y"
+            },
+            "description": "Open Ptime Extension"
+        }
+    },
     "background": {
         "service_worker": "src/background.js"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Ptime Extension",
     "description": "Simple Timer Extension",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "action": {
         "default_popup": "src/index.html",
         "default_icon": {


### PR DESCRIPTION
### Summary
This PR adds a keyboard shortcut (Ctrl+Shift+Y) to open the PTime Extension popup using Chrome's `commands` API.

### Changes
- Updated `manifest.json` to include a `commands` block with `_execute_action`.
- This allows the popup to be opened without clicking the extension icon.

### Shortcut Details
- **Shortcut**: Ctrl+Shift+Y
