### PR TITLE
Add Keyboard Shortcuts for Timer Functions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Ptime Extension",
     "description": "Simple Timer Extension",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "action": {
         "default_popup": "src/index.html",
         "default_icon": {

--- a/src/main.js
+++ b/src/main.js
@@ -119,3 +119,43 @@ chrome.runtime.onMessage.addListener((message) => {
 
 setInterval(refreshTimer, 1000);
 refreshTimer();
+
+document.addEventListener("keydown", (event) => {
+  if (event.target.tagName === 'INPUT') {
+    if (event.key === "Backspace" && !editWrapper.classList.contains("hidden")) {
+        if (document.activeElement.tagName === 'INPUT' && document.activeElement.closest('#edit-wrapper')) {
+            return;
+        }
+        if (!editWrapper.classList.contains("hidden")) {
+            returnButton.click();
+            event.preventDefault();
+        }
+        return;
+    }
+    return;
+  }
+
+  if (editWrapper.classList.contains("hidden")) {
+    switch (event.key.toUpperCase()) {
+      case "S":
+        triggerButton.click();
+        break;
+      case "P":
+        if (triggerButton.textContent === "Pause") {
+          triggerButton.click();
+        }
+        break;
+      case "R":
+        resetTimerButton.click();
+        break;
+      case "E":
+        editTimerButton.click();
+        break;
+    }
+  } else { 
+    if (event.key === "Backspace") {
+      returnButton.click();
+      event.preventDefault();
+    }
+  }
+});


### PR DESCRIPTION
This PR introduces keyboard shortcuts to improve user experience and accessibility:

**Users can now control core timer functions using keyboard shortcuts:**
     - `s` - Start Timer
     - `p` - Pause Timer
     - `r` - Reset Timer
     - `e` - Open Edit Timer
     - `backspace` - Close Edit Timer